### PR TITLE
[UPD] cache actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           echo "CACHE=${{ secrets.CACHE_DATE }} ${{ runner.os }} $(python -VV |
           sha256sum | cut -d' ' -f1) ${{ hashFiles('pyproject.toml') }} ${{
           hashFiles('poetry.lock') }}" >> $GITHUB_ENV
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             .cache.~
@@ -74,7 +74,7 @@ jobs:
     steps:
       # Set up Docker Environment
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             /tmp/.buildx-cache


### PR DESCRIPTION
Actions v2 seems to be deprecated, so updating to v4.