### PR TITLE
[FIX] pin requests library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,4 @@ RUN dnf install -y \
     && sync
 RUN pip install --no-cache-dir poetry
 RUN pip install --no-cache-dir ansible-core==2.12.10
+RUN pip install --no-cache-dir "requests<2.32"


### PR DESCRIPTION
In order to avoid `Error while fetching server API version: Not supported URL scheme http+docker`